### PR TITLE
add ripgrep, add Find command to vim

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -305,6 +305,10 @@ command! FZFMru call fzf#run({
 \  'options': '-m -x +s',
 \  'down':    '40%'})
 
+command! -bang -nargs=* Find call fzf#vim#grep(
+	\ 'rg --column --line-number --no-heading --follow --color=always '.<q-args>, 1,
+	\ <bang>0 ? fzf#vim#with_preview('up:60%') : fzf#vim#with_preview('right:50%:hidden', '?'), <bang>0)
+
 
 " Fugitive Shortcuts
 """""""""""""""""""""""""""""""""""""

--- a/install/brew.sh
+++ b/install/brew.sh
@@ -29,6 +29,7 @@ formulas=(
     wget
     z
     zsh
+    ripgrep
 )
 
 for formula in "${formulas[@]}"; do


### PR DESCRIPTION
Find uses ripgrep as a replacement for ack and Ack.vim. Also, Find! adds a preview pane.